### PR TITLE
Use NotSupportedException for not Implemented functions

### DIFF
--- a/lib/Imagine/Vips/Effects.php
+++ b/lib/Imagine/Vips/Effects.php
@@ -10,6 +10,7 @@
 namespace Imagine\Vips;
 
 use Imagine\Effects\EffectsInterface;
+use Imagine\Exception\NotSupportedException;
 use Imagine\Exception\RuntimeException;
 use Imagine\Image\Palette\Color\ColorInterface;
 use Imagine\Utils\Matrix;
@@ -105,7 +106,7 @@ class Effects implements EffectsInterface
      */
     public function colorize(ColorInterface $color)
     {
-        throw new \RuntimeException(__METHOD__.' not implemented yet in the vips adapter.');
+        throw new NotSupportedException(__METHOD__.' not implemented yet in the vips adapter.');
     }
 
     /**
@@ -148,12 +149,12 @@ class Effects implements EffectsInterface
 
     public function brightness($brightness)
     {
-        throw new \RuntimeException(__METHOD__.' not implemented yet in the vips adapter. You can use modulate() instead.');
+        throw new NotSupportedException(__METHOD__.' not implemented yet in the vips adapter. You can use modulate() instead.');
     }
 
     public function convolve(Matrix $matrix)
     {
-        throw new \RuntimeException(__METHOD__.' not implemented yet in the vips adapter.');
+        throw new NotSupportedException(__METHOD__.' not implemented yet in the vips adapter.');
     }
 
     /**

--- a/lib/Imagine/Vips/Image.php
+++ b/lib/Imagine/Vips/Image.php
@@ -50,7 +50,7 @@ class Image extends AbstractImage
     const ICC_DEFAULT_PROFILE_DEFAULT = 'sRGB.icm';
     const ICC_DEFAULT_PROFILE_BW = 'gray.icc';
     const ICC_DEFAULT_PROFILE_CMYK = 'cmyk.icm';
-    
+
     public const OPTION_JPEG_QUALITY = 'jpeg_quality';
     public const OPTION_PNG_QUALITY = 'png_quality';
 
@@ -511,7 +511,7 @@ class Image extends AbstractImage
     public function interlace($scheme)
     {
         //FIXME: implement in vips
-        throw new \RuntimeException(__METHOD__.' not implemented yet in the vips adapter.');
+        throw new NotSupportedException(__METHOD__.' not implemented yet in the vips adapter.');
     }
 
     /**
@@ -520,7 +520,7 @@ class Image extends AbstractImage
     public function draw()
     {
         //FIXME: implement in vips
-        throw new \RuntimeException(__METHOD__.' not implemented yet in the vips adapter.');
+        throw new NotSupportedException(__METHOD__.' not implemented yet in the vips adapter.');
     }
 
     /**
@@ -602,7 +602,7 @@ class Image extends AbstractImage
     public function fill(FillInterface $fill)
     {
         //FIXME: implement in vips
-        throw new \RuntimeException(__METHOD__.' not implemented yet in the vips adapter.');
+        throw new NotSupportedException(__METHOD__.' not implemented yet in the vips adapter.');
     }
 
     /**
@@ -611,7 +611,7 @@ class Image extends AbstractImage
     public function histogram()
     {
         //FIXME: implement in vips
-        throw new \RuntimeException(__METHOD__.' not implemented yet in the vips adapter.');
+        throw new NotSupportedException(__METHOD__.' not implemented yet in the vips adapter.');
     }
 
     /**
@@ -1165,5 +1165,5 @@ class Image extends AbstractImage
             }
         }
         return $vips;
-}
+    }
 }


### PR DESCRIPTION
Imagine 1.0 which is required by this adapter has introduce a NotSupportedException which should be used if an adapter does not support a specific function.

As it does extend from \RuntimeException this should not be a bc break.