### PR TITLE
Fix gif delay for older vips version

### DIFF
--- a/lib/Imagine/Vips/Image.php
+++ b/lib/Imagine/Vips/Image.php
@@ -1110,7 +1110,11 @@ class Image extends AbstractImage
             $method = 'heifsave';
         } elseif ('gif' == $format) {
             $saveOptions = $this->applySaveOptions(['format' => 'gif'], $options);
-            if($this->vips->typeof('delay') === 0) {
+            $delayProperty = 'delay';
+            if (version_compare(vips_version(), '8.9', '<')) {
+                $delayProperty = 'gif-delay';
+            }
+            if($this->vips->typeof($delayProperty) === 0) {
                 $this->layers()->animate('gif', Layers::DEFAULT_GIF_DELAY, 0);
             }
             $method = 'magicksave';


### PR DESCRIPTION
Think for older vips version we need to go on gif-delay else the gif ends in false delay:

See also:

https://github.com/rokka-io/imagine-vips/blob/63d843dfd8336ffb2ea47029d6c0f05d01a6330d/lib/Imagine/Vips/Layers.php#L92-L106

# Example

Vips Version: vips-8.8.4-Thu

*Original:*

![screenshots](https://user-images.githubusercontent.com/1698337/74537785-0f810580-4f3b-11ea-83c2-1358936d4841.gif)

*Resized before this PR:* 

![screenshot-resized](https://user-images.githubusercontent.com/1698337/74537801-160f7d00-4f3b-11ea-9e08-b40c39f87ab3.gif)
