### PR TITLE
Add support for nsgif loader

### DIFF
--- a/lib/Imagine/Vips/Imagine.php
+++ b/lib/Imagine/Vips/Imagine.php
@@ -203,6 +203,7 @@ class Imagine extends AbstractImagine
                 break;
             case 'VipsForeignLoadGifFile':
             case 'VipsForeignLoadGifBuffer':
+            case 'VipsForeignLoadNsgifBuffer':    
                 $options['n'] = -1; // not sure this should be enabled by default, to discuss
                 break;
         }


### PR DESCRIPTION
Alternative gif loader supported by vips. 
We need to add support for it to ensure animated gif files are loaded correctly.

Fix issue #22 