### PR TITLE
Fix types issues with PHP 8.1

### DIFF
--- a/lib/Imagine/Image/VipsProfile.php
+++ b/lib/Imagine/Image/VipsProfile.php
@@ -77,11 +77,6 @@ class VipsProfile implements ProfileInterface
         return new self(basename($path), file_get_contents($path), $path);
     }
 
-    /**
-     * @param string $profile
-     *
-     * @return string
-     */
     protected static function getTmpFileFromRawData(string $profile): string
     {
         $profileMd5 = md5($profile);

--- a/lib/Imagine/Vips/Drawer.php
+++ b/lib/Imagine/Vips/Drawer.php
@@ -38,16 +38,14 @@ class Drawer implements DrawerInterface
     }
 
     /**
-     * Draw text onto an image
+     * Draw text onto an image.
      *
      * This code is not totally tested, but works basically.
      *
      * @param $string
-     * @param \Imagine\Image\AbstractFont $font
-     * @param \Imagine\Image\PointInterface $position
-     * @param int $angle
-     * @param null $width
-     * @param null $height
+     * @param int    $angle
+     * @param null   $width
+     * @param null   $height
      * @param string $align
      *
      * @throws \FontLib\Exception\FontNotFoundException
@@ -55,7 +53,6 @@ class Drawer implements DrawerInterface
      * @throws \Imagine\Exception\RuntimeException
      * @throws \Jcupitt\Vips\Exception
      */
-
     public function textWithHeight(
         $string,
         AbstractFont $font,

--- a/lib/Imagine/Vips/Drawer.php
+++ b/lib/Imagine/Vips/Drawer.php
@@ -15,6 +15,11 @@ use Jcupitt\Vips\Image as VipsImage;
 
 class Drawer implements DrawerInterface
 {
+    /**
+     * @var \Imagine\Vips\Image
+     */
+    private $image;
+
     public function __construct(Image $image)
     {
         $this->image = $image;
@@ -28,6 +33,8 @@ class Drawer implements DrawerInterface
         $width = null
     ) {
         $this->textWithHeight($string, $font, $position, $angle, $width);
+
+        return $this;
     }
 
     /**

--- a/lib/Imagine/Vips/Effects.php
+++ b/lib/Imagine/Vips/Effects.php
@@ -98,6 +98,7 @@ class Effects implements EffectsInterface
         } catch (Exception $e) {
             throw new RuntimeException('Failed to grayscale the image', $e->getCode(), $e);
         }
+
         return $this;
     }
 
@@ -163,14 +164,12 @@ class Effects implements EffectsInterface
      * @param int $brightness Multiplier in percent
      * @param int $saturation Multiplier in percent
      * @param int $hue        rotate by degrees on the color wheel, 0/360 don't change anything
-     *
-     * @return RokkaImageInterface
      */
-
-    public function modulate(int $brightness = 100, int $saturation = 100, int $hue = 0): RokkaImageInterface
+    public function modulate(int $brightness = 100, int $saturation = 100, int $hue = 0): self
     {
-        $originalColorspace = $this->vips->interpretation;
-        $lch = $this->vips->colourspace(Interpretation::LCH);
+        $vips = $this->image->getVips();
+        $originalColorspace = $vips->interpretation;
+        $lch = $vips->colourspace(Interpretation::LCH);
         $multiply = [$brightness / 100, $saturation / 100, 1];
         if ($lch->hasAlpha()) {
             $multiply[] = 1;
@@ -189,7 +188,7 @@ class Effects implements EffectsInterface
             $originalColorspace = Interpretation::SRGB;
         }
         $image = $lch->colourspace($originalColorspace);
-        $this->setVips($image);
+        $this->image->setVips($image);
 
         return $this;
     }

--- a/lib/Imagine/Vips/Font.php
+++ b/lib/Imagine/Vips/Font.php
@@ -20,9 +20,8 @@ use Jcupitt\Vips\Image as VipsImage;
 final class Font extends AbstractFont
 {
     /**
-     * @param string         $file
-     * @param int            $size
-     * @param ColorInterface $color
+     * @param string $file
+     * @param int    $size
      */
     public function __construct($file, $size, ColorInterface $color)
     {

--- a/lib/Imagine/Vips/Image.php
+++ b/lib/Imagine/Vips/Image.php
@@ -72,10 +72,12 @@ class Image extends AbstractImage
      * @var VipsImage
      */
     protected $vips;
+
     /**
-     * @var Layers
+     * @var \Imagine\Image\LayersInterface
      */
     protected $layers;
+
     /**
      * @var PaletteInterface
      */
@@ -790,7 +792,8 @@ class Image extends AbstractImage
             return $image;
         }
         $i = 0;
-        foreach ($this->layers()->getResources() as $res) {
+        foreach ($this->layers() as $layer) {
+            $res = $layer->getResources();
             if (0 == $i) {
                 ++$i;
                 continue;
@@ -1188,7 +1191,7 @@ class Image extends AbstractImage
      * @throws \Imagine\Exception\RuntimeException
      * @throws \Jcupitt\Vips\Exception
      */
-    private function joinMultilayer($format, self $image): \Jcupitt\Vips\Image
+    private function joinMultilayer($format, self $image): VipsImage
     {
         $vips = $this->getVips();
         if ((('webp' === $format && version_compare(vips_version(), '8.8.0', '>='))
@@ -1199,7 +1202,8 @@ class Image extends AbstractImage
             $width = $vips->width;
             $vips->set('page-height', $height);
 
-            foreach ($image->layers()->getResources() as $_k => $_v) {
+            foreach ($image->layers() as $_k => $layer) {
+                $_v = $layer->getResources();
                 if (0 === $_k) {
                     continue;
                 }

--- a/lib/Imagine/Vips/Layers.php
+++ b/lib/Imagine/Vips/Layers.php
@@ -101,7 +101,8 @@ class Layers extends AbstractLayers
         if($vips->typeof('page-height') === 0) {
             $vips->set("page-height", (int) ($vips->height / count($this)));
         }
-        $this->vips = $vips;
+        $this->image->setVips($vips);
+
         return $this;
     }
 
@@ -133,12 +134,14 @@ class Layers extends AbstractLayers
             $this->resources[$i] = $frame;
             ++$i;
         }
+
+        return $this;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function current()
+    public function current(): Image
     {
         return $this->extractAt($this->offset);
     }
@@ -146,7 +149,7 @@ class Layers extends AbstractLayers
     /**
      * {@inheritdoc}
      */
-    public function key()
+    public function key(): int
     {
         return $this->offset;
     }
@@ -154,7 +157,7 @@ class Layers extends AbstractLayers
     /**
      * {@inheritdoc}
      */
-    public function next()
+    public function next(): void
     {
         ++$this->offset;
     }
@@ -162,7 +165,7 @@ class Layers extends AbstractLayers
     /**
      * {@inheritdoc}
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->offset = 0;
     }
@@ -170,15 +173,15 @@ class Layers extends AbstractLayers
     /**
      * {@inheritdoc}
      */
-    public function valid()
+    public function valid(): bool
     {
-        return $this->offset < count($this);
+        return $this->offset < \count($this);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function count()
+    public function count(): int
     {
         return $this->count;
     }
@@ -186,15 +189,15 @@ class Layers extends AbstractLayers
     /**
      * {@inheritdoc}
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
-        return is_int($offset) && $offset >= 0 && $offset < count($this);
+        return \is_int($offset) && $offset >= 0 && $offset < \count($this);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): Image
     {
         return $this->extractAt($offset);
     }
@@ -202,7 +205,7 @@ class Layers extends AbstractLayers
     /**
      * {@inheritdoc}
      */
-    public function offsetSet($offset, $image)
+    public function offsetSet($offset, $image): void
     {
         if ($offset === null) {
             $offset = $this->count;
@@ -227,7 +230,7 @@ class Layers extends AbstractLayers
     /**
      * {@inheritdoc}
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         throw new NotSupportedException("Removing frames is not supported yet.");
     }


### PR DESCRIPTION
* Make it run on PHP 8.1 without warnings
* Fix some other small type issues
* BC break, if you extended `\Imagine\Vips\Layers`. You need to add some return types now
 
Thanks for the inspiration by @batyrmastyr in #13 and @erickloss in #26 
