### PR TITLE
Enable PHP 8.2 tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        php: ['7.4', '8.0', '8.1' ]
+        php: ['7.4', '8.0', '8.1']
         settings: ['both', 'vips-only', 'ffi-only']
         COMPOSER_FLAGS: ['']
 
@@ -30,7 +30,12 @@ jobs:
           - php: '8.0'
             COMPOSER_FLAGS: "--prefer-lowest"
             settings: 'ffi-only'
-
+          # currently fails on PHP 8.2 with vips-only, due to https://github.com/libvips/php-vips/pull/174
+          # once php-vips 1.0.10 is out, we can enable tests for PHP 8.2 for all "settings" and put this above in matrix.php
+          - php: '8.2'
+            settings: 'ffi-only'
+          - php: '8.2'
+            settings: 'both'
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "imagine/imagine": "^1.0",
-        "jcupitt/vips" : "^2.1.0 || ^1.0.3",
+        "jcupitt/vips" : "^2.1.1 || ^1.0.3",
         "phenx/php-font-lib": "^0.5.2"
 
     },


### PR DESCRIPTION
Only ffi (php-vips 2.0) method currently
For vips extension based, we have to wait for php-vips 1.0.10 -> https://github.com/libvips/php-vips/pull/174
