### PR TITLE
Update font box for more accurate size

### DIFF
--- a/lib/Imagine/Vips/Font.php
+++ b/lib/Imagine/Vips/Font.php
@@ -33,8 +33,15 @@ final class Font extends AbstractFont
      */
     public function box($string, $angle = 0)
     {
-        // FIXME, doesn't work for me, maybe I don't have text support compiled in?
-        $text = VipsImage::text($string, ['font' => $this->file, 'size' => $this->size, 'dpi' => 300]);
+        $resize = 4;
+        $FL = \FontLib\Font::load($this->file);
+
+        $text = VipsImage::text($string, [
+            'fontfile' => $this->file,
+            'font' => $FL->getFontFullName() . ' ' . $this->size * $resize,
+            'width' => $this->size * $resize,
+            'dpi' => 96
+        ]);
 
         return new Box($text->width, $text->height);
     }


### PR DESCRIPTION
return a more accurate box size for the rendered text. resize value is copied from the actual drawer text option. DPI is changed to 96 to match the other Imagine adapters