### PR TITLE
Update text functions 

### DIFF
--- a/lib/Imagine/Vips/Font.php
+++ b/lib/Imagine/Vips/Font.php
@@ -33,8 +33,15 @@ final class Font extends AbstractFont
      */
     public function box($string, $angle = 0)
     {
-        // FIXME, doesn't work for me, maybe I don't have text support compiled in?
-        $text = VipsImage::text($string, ['font' => $this->file, 'size' => $this->size, 'dpi' => 300]);
+        $resize = 4;
+        $FL = \FontLib\Font::load($this->file);
+
+        $text = VipsImage::text($string, [
+            'fontfile' => $this->file,
+            'font' => $FL->getFontFullName() . ' ' . $this->size * $resize,
+            'width' => $this->size * $resize,
+            'dpi' => 96
+        ]);
 
         return new Box($text->width, $text->height);
     }

--- a/lib/Imagine/Vips/Font.php
+++ b/lib/Imagine/Vips/Font.php
@@ -33,14 +33,14 @@ final class Font extends AbstractFont
      */
     public function box($string, $angle = 0)
     {
-        $resize = 4;
         $FL = \FontLib\Font::load($this->file);
 
+        $fontSize = (int)($this->size * (96 / 72));
         $text = VipsImage::text($string, [
             'fontfile' => $this->file,
-            'font' => $FL->getFontFullName() . ' ' . $this->size * $resize,
-            'width' => $this->size * $resize,
-            'dpi' => 96
+            'font' => $FL->getFontFullName() . ' ' . $fontSize,
+            'dpi' => 72,
+            'height' => $fontSize
         ]);
 
         return new Box($text->width, $text->height);


### PR DESCRIPTION
This will make this library handle text like the other Imagine adapters.  I left the "with height" function alone so if someone expects the prior behavior, they can call that directly. However, swapping between adapters will present similar results now. I could not get the library to render animated gif so I did not make the text method work with that (and overall, Imagine can't handle animated png or webp either).