### PR TITLE
Test with vips on PHP 8.2 extension also

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        php: ['7.4', '8.0', '8.1']
+        php: ['7.4', '8.0', '8.1', '8.2']
         settings: ['both', 'vips-only', 'ffi-only']
         COMPOSER_FLAGS: ['']
 
@@ -30,12 +30,6 @@ jobs:
           - php: '8.0'
             COMPOSER_FLAGS: "--prefer-lowest"
             settings: 'ffi-only'
-          # currently fails on PHP 8.2 with vips-only, due to https://github.com/libvips/php-vips/pull/174
-          # once php-vips 1.0.10 is out, we can enable tests for PHP 8.2 for all "settings" and put this above in matrix.php
-          - php: '8.2'
-            settings: 'ffi-only'
-          - php: '8.2'
-            settings: 'both'
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
Needs a new release of php-vips on the 1.x branch (1.0.10, I assume)