### PR TITLE
Fix autorotate in Imagine.php

### DIFF
--- a/lib/Imagine/Vips/Imagine.php
+++ b/lib/Imagine/Vips/Imagine.php
@@ -243,7 +243,7 @@ class Imagine extends AbstractImagine
                 $options['n'] = -1;
                 break;
         }
-        $options = array_merge($loadOptions, $options);
+        $options = array_merge($options, $loadOptions);
         // FIXME: remove not allowed options
 
         if (isset($options['shrink'])) {


### PR DESCRIPTION
Problem: autorotate is always on, there is no way to turn it off (https://github.com/rokka-io/imagine-vips/issues/20)
This one-line patch fixes the problem.

