### PR TITLE
Detection for vips 1 not longer works

### DIFF
--- a/.github/workflows/settings/both.json
+++ b/.github/workflows/settings/both.json
@@ -1,4 +1,5 @@
 {
     "extensions": "",
+    "ini_values": "ffi.enable=true, zend.max_allowed_stack_size=-1",
     "aptinstall": "libvips-dev"
 }

--- a/.github/workflows/settings/ffi-only.json
+++ b/.github/workflows/settings/ffi-only.json
@@ -1,4 +1,5 @@
 {
     "extensions": "",
+    "ini_values": "ffi.enable=true, zend.max_allowed_stack_size=-1",
     "aptinstall": "libvips"
 }

--- a/.github/workflows/settings/vips-only.json
+++ b/.github/workflows/settings/vips-only.json
@@ -1,4 +1,5 @@
 {
     "extensions": ":ffi",
+    "ini_values": "",
     "aptinstall": "libvips-dev"
 }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Debug PHP settings
         run: |
-          php -r 'echo "Has VIPS Extension: " . (extension_loaded("vips") ? "true" : "false") . PHP_EOL; Has FFI Extension: " . (extension_loaded("ffi") ? "true" : "false") . PHP_EOL; echo "Has FFI Class: " . (class_exists(FFI::class) ? "true" : "false") . PHP_EOL; echo "Has FFI Enabled: " . (ini_get("ffi.enable") === "1" ? "true" : "false") . PHP_EOL; echo "Has zend.max_allowed_stack_size correct: " . (ini_get("zend.max_allowed_stack_size") === "-1" ? "true" : "false") . PHP_EOL;'
+          php -r 'echo "Has VIPS Extension: " . (extension_loaded("vips") ? "true" : "false") . PHP_EOL; Has FFI Extension: " . (extension_loaded("ffi") ? "true" : "false") . PHP_EOL; echo "Has FFI Class: " . (class_exists("FFI") ? "true" : "false") . PHP_EOL; echo "Has FFI Enabled: " . (ini_get("ffi.enable") === "1" ? "true" : "false") . PHP_EOL; echo "Has zend.max_allowed_stack_size correct: " . (ini_get("zend.max_allowed_stack_size") === "-1" ? "true" : "false") . PHP_EOL;'
 
       - name: PHPStan
         run: composer phpstan

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Debug PHP settings
         run: |
-          php -r 'echo "Has FFI Extension: " . (extension_loaded("ffi") ? "true" : "false") . PHP_EOL; echo "Has FFI Class: " . (class_exists(FFI::class) ? "true" : "false") . PHP_EOL; echo "Has FFI Enabled: " . (ini_get("ffi.enable") === "1" ? "true" : "false") . PHP_EOL; echo "Has zend.max_allowed_stack_size correct: " . (ini_get("zend.max_allowed_stack_size") === "-1" ? "true" : "false") . PHP_EOL;'
+          php -r 'echo "Has VIPS Extension: " . (extension_loaded("vips") ? "true" : "false") . PHP_EOL; Has FFI Extension: " . (extension_loaded("ffi") ? "true" : "false") . PHP_EOL; echo "Has FFI Class: " . (class_exists(FFI::class) ? "true" : "false") . PHP_EOL; echo "Has FFI Enabled: " . (ini_get("ffi.enable") === "1" ? "true" : "false") . PHP_EOL; echo "Has zend.max_allowed_stack_size correct: " . (ini_get("zend.max_allowed_stack_size") === "-1" ? "true" : "false") . PHP_EOL;'
 
       - name: PHPStan
         run: composer phpstan

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,4 +82,5 @@ jobs:
         run: composer phpunit
 
       - name: Composer audit
-        run: composer audit
+        run: |
+          composer audit --no-dev

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,6 +63,10 @@ jobs:
       - name: Install vips ext config
         run:  echo "extension=vips.so" >> $(php -i | grep /.+/php.ini -oE)
         if: fromJson(env.SETTINGS_JSON).aptinstall == 'libvips-dev'
+        
+      - name: Enable ffi # preload is currently not supported. See https://github.com/libvips/php-vips
+        run:  echo "ffi.enable = true" >> $(php -i | grep /.+/php.ini -oE)
+        if: fromJson(env.SETTINGS_JSON).aptinstall == 'libvips-dev'
 
       - name: Install composer dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           tools: composer:v2
+          ini-values: ${{fromJson(env.SETTINGS_JSON).ini_values}}
           coverage: none
           extensions: ${{fromJson(env.SETTINGS_JSON).extensions}}
 
@@ -62,14 +63,6 @@ jobs:
 
       - name: Install vips ext config
         run:  echo "extension=vips.so" >> $(php -i | grep /.+/php.ini -oE)
-        if: fromJson(env.SETTINGS_JSON).aptinstall == 'libvips-dev'
-        
-      - name: Enable ffi # preload is currently not supported. See https://github.com/libvips/php-vips
-        run:  echo "ffi.enable = true" >> $(php -i | grep /.+/php.ini -oE)
-        if: fromJson(env.SETTINGS_JSON).aptinstall == 'libvips-dev'
-        
-      - name: Disable zend.max_allowed_stack_size # See https://github.com/libvips/php-vips
-        run:  echo "zend.max_allowed_stack_size = -1" >> $(php -i | grep /.+/php.ini -oE)
         if: fromJson(env.SETTINGS_JSON).aptinstall == 'libvips-dev'
 
       - name: Install composer dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,6 +67,10 @@ jobs:
       - name: Enable ffi # preload is currently not supported. See https://github.com/libvips/php-vips
         run:  echo "ffi.enable = true" >> $(php -i | grep /.+/php.ini -oE)
         if: fromJson(env.SETTINGS_JSON).aptinstall == 'libvips-dev'
+        
+      - name: Disable zend.max_allowed_stack_size # See https://github.com/libvips/php-vips
+        run:  echo "zend.max_allowed_stack_size = -1" >> $(php -i | grep /.+/php.ini -oE)
+        if: fromJson(env.SETTINGS_JSON).aptinstall == 'libvips-dev'
 
       - name: Install composer dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,6 +68,10 @@ jobs:
         run: |
           composer update --prefer-dist --no-interaction --no-progress --no-ansi ${{ matrix.COMPOSER_FLAGS || '' }}
 
+      - name: Debug PHP settings
+        run: |
+          php -r 'echo "Has FFI Extension: " . (extension_loaded("ffi") ? "true" : "false") . PHP_EOL; echo "Has FFI Class: " . (class_exists(FFI::class) ? "true" : "false") . PHP_EOL; echo "Has FFI Enabled: " . (ini_get("ffi.enable") === "1" ? "true" : "false") . PHP_EOL; echo "Has zend.max_allowed_stack_size correct: " . (ini_get("zend.max_allowed_stack_size") === "-1" ? "true" : "false") . PHP_EOL;'
+
       - name: PHPStan
         run: composer phpstan
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Debug PHP settings
         run: |
-          php -r 'echo "Has VIPS Extension: " . (extension_loaded("vips") ? "true" : "false") . PHP_EOL; Has FFI Extension: " . (extension_loaded("ffi") ? "true" : "false") . PHP_EOL; echo "Has FFI Class: " . (class_exists("FFI") ? "true" : "false") . PHP_EOL; echo "Has FFI Enabled: " . (ini_get("ffi.enable") === "1" ? "true" : "false") . PHP_EOL; echo "Has zend.max_allowed_stack_size correct: " . (ini_get("zend.max_allowed_stack_size") === "-1" ? "true" : "false") . PHP_EOL;'
+          php -r 'echo "Has VIPS Extension: " . (extension_loaded("vips") ? "true" : "false") . PHP_EOL; echo "Has FFI Extension: " . (extension_loaded("ffi") ? "true" : "false") . PHP_EOL; echo "Has FFI Class: " . (class_exists(FFI::class) ? "true" : "false") . PHP_EOL; echo "Has FFI Enabled: " . (ini_get("ffi.enable") === "1" ? "true" : "false") . PHP_EOL; echo "Has zend.max_allowed_stack_size correct: " . (ini_get("zend.max_allowed_stack_size") === "-1" ? "true" : "false") . PHP_EOL;'
 
       - name: PHPStan
         run: composer phpstan

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        php: ['7.4', '8.0', '8.1']
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         settings: ['both', 'vips-only', 'ffi-only']
         COMPOSER_FLAGS: ['']
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,9 @@ jobs:
           extensions: ${{fromJson(env.SETTINGS_JSON).extensions}}
 
       - name: Install vips
-        run: sudo apt install -y  ${{fromJson(env.SETTINGS_JSON).aptinstall}} --no-install-recommends
+        run: |
+          sudo apt update
+          sudo apt install -y  ${{fromJson(env.SETTINGS_JSON).aptinstall}} --no-install-recommends
 
       - name: Install vips extension
         run: sudo pecl install vips

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -30,7 +30,16 @@ return $config
         'strict_param' => true,
         'native_function_invocation' => ['include' => ['@compiler_optimized']],
         'phpdoc_no_empty_return' => false,
-        'no_superfluous_phpdoc_tags' => true,
+        'no_superfluous_phpdoc_tags' => false,
+        'fully_qualified_strict_types' => false,
+        'native_function_invocation' => false,
+        'no_null_property_initialization' => false,
+        'phpdoc_trim' => false,
+        'blank_line_before_statement' => false,
+        'phpdoc_add_missing_param_annotation' => false,
+        'modernize_strpos' => false,
+        'trailing_comma_in_multiline' => false,
+        'no_whitespace_in_blank_line' => false,
     ])
     ->setFinder(
         $finder

--- a/lib/Imagine/Vips/Image.php
+++ b/lib/Imagine/Vips/Image.php
@@ -310,7 +310,7 @@ class Image extends AbstractImage
         return $this->vips->copyMemory();
     }
 
-    public static function generateImage(BoxInterface $size, ColorInterface $color = null)
+    public static function generateImage(BoxInterface $size, ?ColorInterface $color = null)
     {
         $width = $size->getWidth();
         $height = $size->getHeight();
@@ -385,7 +385,7 @@ class Image extends AbstractImage
      *
      * @return ImageInterface
      */
-    public function rotate($angle, ColorInterface $background = null)
+    public function rotate($angle, ?ColorInterface $background = null)
     {
         $color = $background ?: $this->palette->color('fff');
         try {
@@ -768,7 +768,7 @@ class Image extends AbstractImage
      *
      * @return ImageInterface
      */
-    public function convertToAlternative(ImagineInterface $imagine = null, array $tiffOptions = [], $asTiff = false)
+    public function convertToAlternative(?ImagineInterface $imagine = null, array $tiffOptions = [], $asTiff = false)
     {
         if (null === $imagine) {
             $oldMetaReader = null;

--- a/lib/Imagine/Vips/Imagine.php
+++ b/lib/Imagine/Vips/Imagine.php
@@ -202,20 +202,25 @@ class Imagine extends AbstractImagine
     public static function hasVipsInstalled()
     {
         try {
-            // this method only exists in php-vips 2.0
-            if (class_exists(FFI::class)) {
-                // if ffi extension is not installed, we can't use php-vips
-                if (!\extension_loaded('ffi')) {
-                    return false;
-                }
+            // if we're still on php-vips 1.0, check if 'vips' extension is installed
+            if (\extension_loaded('vips')) {
+                return true;
+            }
+            
+            if (class_exists(FFI::class)
+                // if ffi extension is not installed, we can't use php-vips 2
+                && extension_loaded('ffi')
+                // preload is not yet supported by vips see https://github.com/libvips/php-vips
+                && '1' === \ini_get('ffi.enable')
+            ) {
                 // this will throw an exception, if libvips is not installed
                 // will return false in the catch block
                 Config::version();
 
                 return true;
             }
-            // if we're still on php-vips 1.0, check if 'vips' extension is installed
-            return \extension_loaded('vips');
+            
+            return false;
         } catch (\Exception $e) {
             return false;
         }

--- a/lib/Imagine/Vips/Imagine.php
+++ b/lib/Imagine/Vips/Imagine.php
@@ -96,7 +96,7 @@ class Imagine extends AbstractImagine
     /**
      * {@inheritdoc}
      */
-    public function create(BoxInterface $size, ColorInterface $color = null)
+    public function create(BoxInterface $size, ?ColorInterface $color = null)
     {
         $vips = Image::generateImage($size, $color);
 

--- a/lib/Imagine/Vips/Layers.php
+++ b/lib/Imagine/Vips/Layers.php
@@ -45,7 +45,7 @@ class Layers extends AbstractLayers
      */
     private $count = 0;
 
-    public function __construct(Image $image, self $layers = null)
+    public function __construct(Image $image, ?self $layers = null)
     {
         $this->image = $image;
 


### PR DESCRIPTION
The implementation previously was https://github.com/rokka-io/imagine-vips/commit/f159d2495d8b10a7d45988ccca31f809421670ab

Not sure when but `if (\method_exists(Config::class, 'ffi')) {` was replaced by `class_exists(FFI::class)` which seems now not longer fallback then to check for v1 version as FFI class always exist im basic PHP core installations.