### PR TITLE
Update support of phenx/php-font-lib to 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "php": "^7.2 || ^8.0",
         "imagine/imagine": "^1.0",
         "jcupitt/vips" : "^2.1.1 || ^1.0.3",
-        "phenx/php-font-lib": "^0.5.2"
+        "phenx/php-font-lib": "^0.5.2 || ^1.0"
 
     },
     "require-dev": {


### PR DESCRIPTION
A new version of phenx/php-font-lib was released in december.

There where not lot of changes, maintainer switched: https://github.com/dompdf/php-font-lib/compare/0.5.6...1.0.1. Only code changes was fix for a PHP 8.4 deprecation.